### PR TITLE
Implement `resolve` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ temp-dir = "0.1"
 
 [dependencies]
 asimov-env = { version = "25.0.0-dev.3" }
+# TODO: upload a new release and import it
+asimov-module = { path = "../asimov.rs/lib/asimov-module" }
 clap = { version = "4.5", default-features = false }
 clientele = { version = "0.3", features = ["serde-json", "tokio"] }
 color-print = "=0.3.7"
@@ -55,6 +57,7 @@ tokio = { version = "1", features = ["full"] }
 zip = "4"
 flate2 = "1"
 tar = "0.4"
+serde_yml = { version = "0.0.12", default-features = false }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 openssl = { version = "0.10", features = ["vendored"] }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -26,6 +26,9 @@ pub use link::*;
 mod list;
 pub use list::*;
 
+mod resolve;
+pub use resolve::*;
+
 mod uninstall;
 pub use uninstall::*;
 

--- a/src/commands/resolve.rs
+++ b/src/commands/resolve.rs
@@ -1,0 +1,104 @@
+// This is free and unencumbered software released into the public domain.
+
+use std::{error::Error, path::PathBuf};
+
+use crate::{
+    registry::{self, ModuleMetadata},
+    StandardOptions, SysexitsError,
+};
+use asimov_env::paths::asimov_root;
+use asimov_module::resolve::ResolverBuilder;
+use color_print::{ceprintln, cprint, cprintln};
+
+#[tokio::main]
+pub async fn resolve(url: impl AsRef<str>, _flags: &StandardOptions) -> Result<(), SysexitsError> {
+    let mut builder = ResolverBuilder::new();
+
+    let dir = std::fs::read_dir(asimov_root().join("modules")).inspect_err(|e| {
+        ceprintln!("<r,s>error:</> failed to read module manifest directory: {e}")
+    })?;
+
+    for entry in dir {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let name = path.to_string_lossy();
+        if !name.ends_with(".yaml") && !name.ends_with(".yml") {
+            continue;
+        }
+        if let Err(e) = import_module_manifest(&mut builder, &path) {
+            ceprintln!(
+                "<y,s>warning:</> skipping module manifest at {}: {e}",
+                path.display()
+            )
+        }
+    }
+
+    let resolver = builder.build()?;
+
+    let modules = resolver.resolve(url.as_ref())?;
+    for module in modules {
+        // let Some(module) = crate::registry::fetch_module(&module.name).await else {
+        //     continue;
+        // };
+
+        // if module.is_installed()? {
+        //     cprint!("<g,s>✓</> ");
+        // } else {
+        //     cprint!("<r,s>✗</> ");
+        // }
+        // cprintln!("{}", module.name);
+
+        cprintln!("{}", module.name);
+    }
+
+    Ok(())
+}
+
+fn import_module_manifest(
+    builder: &mut ResolverBuilder,
+    path: &PathBuf,
+) -> Result<(), Box<dyn Error>> {
+    let manifest = std::fs::File::open(path)?;
+    let module: serde_yml::Mapping = serde_yml::from_reader(manifest)?;
+    let name = &module["name"]
+        .as_str()
+        .ok_or("Invalid module manifest: no name")?;
+
+    if let Some(protocols) = module["handles"]["url_protocols"].as_sequence() {
+        for protocol in protocols {
+            builder.insert_protocol(
+                name,
+                protocol
+                    .as_str()
+                    .ok_or("Invalid module manifest: malformed handles.url_protocols")?,
+            )?
+        }
+    }
+
+    if let Some(prefixes) = module["handles"]["url_prefixes"].as_sequence() {
+        for prefix in prefixes {
+            builder.insert_prefix(
+                name,
+                prefix
+                    .as_str()
+                    .ok_or("Invalid module manifest: malformed handles.url_prefixes")?,
+            )?
+        }
+    }
+
+    if let Some(patterns) = module["handles"]["url_patterns"].as_sequence() {
+        for pattern in patterns {
+            builder.insert_pattern(
+                name,
+                pattern
+                    .as_str()
+                    .ok_or("Invalid module manifest: malformed handles.url_patterns")?,
+            )?
+        }
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,12 @@ enum Command {
     #[clap(alias = "ls")]
     List {},
 
+    /// Resolve to modules which can handle the given URL
+    Resolve {
+        /// The URL to resolve
+        url: String,
+    },
+
     /// Uninstall a currently installed module
     Uninstall {
         /// The names of the modules to uninstall
@@ -137,6 +143,7 @@ pub fn main() -> SysexitsError {
         Command::Install { names } => commands::install(names, &options.flags),
         Command::Link { name } => commands::link(name, &options.flags),
         Command::List {} => commands::list(&options.flags),
+        Command::Resolve { url } => commands::resolve(url, &options.flags),
         Command::Uninstall { names } => commands::uninstall(names, &options.flags),
         #[cfg(feature = "unstable")]
         Command::Upgrade { names } => commands::upgrade(names, &options.flags),


### PR DESCRIPTION
- Assumes install would add module manifests to `~/.asimov/modules` something like `mkdir ~/.asimov/modules && curl -o ~/.asimov/modules/brightdata.yaml https://raw.githubusercontent.com/asimov-modules/asimov-brightdata-module/refs/heads/master/.asimov/module.yaml`
- I'd like to check the install status with `crate::registry::fetch_module(&module.name)` (commented in code) to show whether the module is installed. Possibly would make sense to split local resolve and "remote" resolve (i.e. fetch modules manifests from registry and do the resolve). Not currently possible (modules not in registries)