### PR TITLE
Improve error messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,8 @@ zip = "4"
 flate2 = "1"
 tar = "0.4"
 serde_yml = { version = "0.0.12", default-features = false }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 openssl = { version = "0.10", features = ["vendored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ temp-dir = "0.1"
 
 [dependencies]
 asimov-env = { version = "25.0.0-dev.3" }
-asimov-module = { version = "25.0.0-dev.10" }
+asimov-module = { version = "25.0.0-dev.12" }
 clap = { version = "4.5", default-features = false }
 clientele = { version = "0.3", features = ["serde-json", "tokio"] }
 color-print = "=0.3.7"

--- a/src/commands/browse.rs
+++ b/src/commands/browse.rs
@@ -15,9 +15,8 @@ pub async fn browse(
 
     match registry::fetch_module(module_name).await {
         Some(module) => {
-            open::that(&module.url).inspect_err(|e| {
-                eprintln!("failed to open URL '{}': {}", module.url, e);
-            })?;
+            open::that(&module.url)
+                .inspect_err(|e| tracing::error!("failed to open URL '{}': {e}", module.url))?;
             Ok(())
         }
         None => {

--- a/src/commands/browse.rs
+++ b/src/commands/browse.rs
@@ -1,6 +1,10 @@
 // This is free and unencumbered software released into the public domain.
 
-use crate::{registry, StandardOptions, SysexitsError};
+use crate::{
+    StandardOptions,
+    SysexitsError::{self, *},
+    registry,
+};
 
 #[tokio::main]
 pub async fn browse(
@@ -11,12 +15,14 @@ pub async fn browse(
 
     match registry::fetch_module(module_name).await {
         Some(module) => {
-            open::that(module.url)?;
+            open::that(&module.url).inspect_err(|e| {
+                eprintln!("failed to open URL '{}': {}", module.url, e);
+            })?;
             Ok(())
         }
         None => {
             eprintln!("unknown module: {}", module_name);
-            Err(SysexitsError::EX_UNAVAILABLE)
+            Err(EX_UNAVAILABLE)
         }
     }
 }

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -1,6 +1,10 @@
 // This is free and unencumbered software released into the public domain.
 
-use crate::{registry, StandardOptions, SysexitsError};
+use crate::{
+    StandardOptions,
+    SysexitsError::{self, *},
+    registry,
+};
 
 #[tokio::main]
 pub async fn link(
@@ -15,7 +19,7 @@ pub async fn link(
         }
         None => {
             eprintln!("unknown module: {}", module_name);
-            Err(SysexitsError::EX_UNAVAILABLE)
+            Err(EX_UNAVAILABLE)
         }
     }
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -38,8 +38,18 @@ pub async fn list(flags: &StandardOptions) -> Result<(), SysexitsError> {
         }
     }
 
-    for module in registry::fetch_modules().await? {
-        let is_installed = module.is_installed()?;
+    for module in registry::fetch_modules().await.map_err(|e| {
+        ceprintln!("<s,r>error:</> failed to fetch module registry: {}", e);
+        e
+    })? {
+        let is_installed = module.is_installed().map_err(|e| {
+            ceprintln!(
+                "<s,r>error:</> failed to check if module '{}' is installed: {}",
+                module.name,
+                e
+            );
+            e
+        })?;
         if is_installed {
             cprint!("<s><g>✓</></> ");
         } else {

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -12,9 +12,7 @@ pub async fn list(flags: &StandardOptions) -> Result<(), SysexitsError> {
     if md.is_ok_and(|md| md.is_dir()) {
         let mut module_dir = tokio::fs::read_dir(module_dir_path)
             .await
-            .inspect_err(|e| {
-                ceprintln!("<s,r>error:</> failed to read module manifest directory: {e}")
-            })?;
+            .inspect_err(|e| tracing::error!("failed to read module manifest directory: {e}"))?;
         loop {
             match module_dir.next_entry().await {
                 Ok(None) => break,
@@ -38,17 +36,15 @@ pub async fn list(flags: &StandardOptions) -> Result<(), SysexitsError> {
         }
     }
 
-    for module in registry::fetch_modules().await.map_err(|e| {
-        ceprintln!("<s,r>error:</> failed to fetch module registry: {}", e);
-        e
-    })? {
-        let is_installed = module.is_installed().map_err(|e| {
-            ceprintln!(
-                "<s,r>error:</> failed to check if module '{}' is installed: {}",
+    for module in registry::fetch_modules()
+        .await
+        .inspect_err(|e| tracing::error!("failed to fetch module registry: {e}"))?
+    {
+        let is_installed = module.is_installed().inspect_err(|e| {
+            tracing::error!(
+                "failed to check if module '{}' is installed: {e}",
                 module.name,
-                e
-            );
-            e
+            )
         })?;
         if is_installed {
             cprint!("<s><g>✓</></> ");

--- a/src/commands/resolve.rs
+++ b/src/commands/resolve.rs
@@ -3,7 +3,8 @@
 use std::{error::Error, path::PathBuf};
 
 use crate::{
-    StandardOptions, SysexitsError,
+    StandardOptions,
+    SysexitsError::{self, *},
     registry::{self, ModuleMetadata},
 };
 use asimov_env::paths::asimov_root;
@@ -19,8 +20,18 @@ pub async fn resolve(url: impl AsRef<str>, _flags: &StandardOptions) -> Result<(
     })?;
 
     for entry in dir {
-        let entry = entry?;
-        if !entry.file_type()?.is_file() {
+        let entry = entry
+            .inspect_err(|e| ceprintln!("<r,s>error:</> failed to read directory entry: {e}"))?;
+        if !entry
+            .file_type()
+            .inspect_err(|e| {
+                ceprintln!(
+                    "<r,s>error:</> failed to get file type for '{}': {e}",
+                    entry.path().display()
+                )
+            })?
+            .is_file()
+        {
             continue;
         }
         let path = entry.path();
@@ -29,20 +40,38 @@ pub async fn resolve(url: impl AsRef<str>, _flags: &StandardOptions) -> Result<(
         if !filename.ends_with(".yaml") && !filename.ends_with(".yml") {
             continue;
         }
-        let file = std::fs::File::open(&path)?;
+        let file = std::fs::File::open(&path).inspect_err(|e| {
+            ceprintln!(
+                "<r,s>error:</> failed to open manifest file '{}': {e}",
+                path.display()
+            )
+        })?;
         let manifest: ModuleManifest = serde_yml::from_reader(file).map_err(|e| {
             ceprintln!(
                 "<s,y>warning:</> skipping invalid module manifest at `{}`: {e}",
                 path.display()
             );
-            SysexitsError::EX_UNAVAILABLE
+            EX_UNAVAILABLE
         })?;
-        builder.insert_manifest(&manifest)?;
+        builder.insert_manifest(&manifest).inspect_err(|e| {
+            ceprintln!(
+                "<r,s>error:</> failed to insert manifest from '{}': {e}",
+                path.display()
+            )
+        })?;
     }
 
-    let resolver = builder.build()?;
+    let resolver = builder
+        .build()
+        .inspect_err(|e| ceprintln!("<r,s>error:</> failed to build resolver: {e}"))?;
 
-    let modules = resolver.resolve(url.as_ref())?;
+    let modules = resolver.resolve(url.as_ref()).inspect_err(|e| {
+        ceprintln!(
+            "<r,s>error:</> failed to resolve modules for URL '{}': {e}",
+            url.as_ref()
+        )
+    })?;
+
     for module in modules {
         // let Some(module) = crate::registry::fetch_module(&module.name).await else {
         //     continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,8 @@ pub fn main() -> SysexitsError {
     // Load environment variables from `.env`:
     clientele::dotenv().ok();
 
+    tracing_subscriber::fmt::init();
+
     // Expand wildcards and @argfiles:
     let Ok(args) = clientele::args_os() else {
         return EX_USAGE;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -6,11 +6,15 @@ pub mod http;
 pub mod pypi;
 pub mod rubygems;
 
-use crate::{registry, SysexitsError};
+use crate::{
+    SysexitsError::{self, *},
+    registry,
+};
 use asimov_env::{
     env::Env,
     envs::{PythonEnv, RubyEnv},
 };
+use color_print::ceprintln;
 use derive_more::Display;
 use tokio::task;
 
@@ -71,27 +75,58 @@ pub async fn fetch_modules() -> Result<Vec<ModuleMetadata>, SysexitsError> {
     let rust_task = task::spawn(async {
         let result = registry::crates::fetch_current_modules()
             .await
-            .expect("Fetch Rust module metadata");
-        registry::crates::extract_module_names(result)
+            .map_err(|e| {
+                ceprintln!("<s,r>error:</> failed to fetch Rust module metadata: {}", e);
+                EX_UNAVAILABLE
+            })?;
+        registry::crates::extract_module_names(result).map_err(|e| {
+            ceprintln!("<s,r>error:</> failed to parse Rust module metadata: {}", e);
+            EX_DATAERR
+        })
     });
     let ruby_task = task::spawn(async {
         let result = registry::rubygems::fetch_current_modules()
             .await
-            .expect("Fetch Ruby module metadata");
-        registry::rubygems::extract_module_names(result)
+            .map_err(|e| {
+                ceprintln!("<s,r>error:</> failed to fetch Ruby module metadata: {}", e);
+                EX_UNAVAILABLE
+            })?;
+        registry::rubygems::extract_module_names(result).map_err(|e| {
+            ceprintln!("<s,r>error:</> failed to parse Ruby module metadata: {}", e);
+            EX_DATAERR
+        })
     });
     let python_task = task::spawn(async {
-        let result = registry::pypi::fetch_current_modules()
-            .await
-            .expect("Fetch Python module metadata");
-        registry::pypi::extract_module_names(result)
+        let result = registry::pypi::fetch_current_modules().await.map_err(|e| {
+            ceprintln!(
+                "<s,r>error:</> failed to fetch Python module metadata: {}",
+                e
+            );
+            EX_UNAVAILABLE
+        })?;
+        registry::pypi::extract_module_names(result).map_err(|e| {
+            ceprintln!(
+                "<s,r>error:</> failed to parse Python module metadata: {}",
+                e
+            );
+            EX_DATAERR
+        })
     });
 
     // Await all tasks; note the double ?? to handle both `JoinError` and the
     // `Result` from the task:
-    let rust_modules = rust_task.await??;
-    let ruby_modules = ruby_task.await??;
-    let python_modules = python_task.await??;
+    let rust_modules = rust_task.await.map_err(|e| {
+        ceprintln!("<s,r>error:</> failed to join Rust module task: {}", e);
+        EX_SOFTWARE
+    })??;
+    let ruby_modules = ruby_task.await.map_err(|e| {
+        ceprintln!("<s,r>error:</> failed to join Ruby module task: {}", e);
+        EX_SOFTWARE
+    })??;
+    let python_modules = python_task.await.map_err(|e| {
+        ceprintln!("<s,r>error:</> failed to join Python module task: {}", e);
+        EX_SOFTWARE
+    })??;
 
     let mut all_modules: Vec<ModuleMetadata> = rust_modules
         .iter()

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -14,7 +14,6 @@ use asimov_env::{
     env::Env,
     envs::{PythonEnv, RubyEnv},
 };
-use color_print::ceprintln;
 use derive_more::Display;
 use tokio::task;
 
@@ -76,11 +75,11 @@ pub async fn fetch_modules() -> Result<Vec<ModuleMetadata>, SysexitsError> {
         let result = registry::crates::fetch_current_modules()
             .await
             .map_err(|e| {
-                ceprintln!("<s,r>error:</> failed to fetch Rust module metadata: {}", e);
+                tracing::error!("failed to fetch Rust module metadata: {e}");
                 EX_UNAVAILABLE
             })?;
         registry::crates::extract_module_names(result).map_err(|e| {
-            ceprintln!("<s,r>error:</> failed to parse Rust module metadata: {}", e);
+            tracing::error!("failed to parse Rust module metadata: {e}");
             EX_DATAERR
         })
     });
@@ -88,27 +87,21 @@ pub async fn fetch_modules() -> Result<Vec<ModuleMetadata>, SysexitsError> {
         let result = registry::rubygems::fetch_current_modules()
             .await
             .map_err(|e| {
-                ceprintln!("<s,r>error:</> failed to fetch Ruby module metadata: {}", e);
+                tracing::error!("failed to fetch Ruby module metadata: {e}");
                 EX_UNAVAILABLE
             })?;
         registry::rubygems::extract_module_names(result).map_err(|e| {
-            ceprintln!("<s,r>error:</> failed to parse Ruby module metadata: {}", e);
+            tracing::error!("failed to parse Ruby module metadata: {e}");
             EX_DATAERR
         })
     });
     let python_task = task::spawn(async {
         let result = registry::pypi::fetch_current_modules().await.map_err(|e| {
-            ceprintln!(
-                "<s,r>error:</> failed to fetch Python module metadata: {}",
-                e
-            );
+            tracing::error!("failed to fetch Python module metadata: {e}");
             EX_UNAVAILABLE
         })?;
         registry::pypi::extract_module_names(result).map_err(|e| {
-            ceprintln!(
-                "<s,r>error:</> failed to parse Python module metadata: {}",
-                e
-            );
+            tracing::error!("failed to parse Python module metadata: {e}");
             EX_DATAERR
         })
     });
@@ -116,15 +109,15 @@ pub async fn fetch_modules() -> Result<Vec<ModuleMetadata>, SysexitsError> {
     // Await all tasks; note the double ?? to handle both `JoinError` and the
     // `Result` from the task:
     let rust_modules = rust_task.await.map_err(|e| {
-        ceprintln!("<s,r>error:</> failed to join Rust module task: {}", e);
+        tracing::error!("failed to join Rust module task: {e}");
         EX_SOFTWARE
     })??;
     let ruby_modules = ruby_task.await.map_err(|e| {
-        ceprintln!("<s,r>error:</> failed to join Ruby module task: {}", e);
+        tracing::error!("failed to join Ruby module task: {e}");
         EX_SOFTWARE
     })??;
     let python_modules = python_task.await.map_err(|e| {
-        ceprintln!("<s,r>error:</> failed to join Python module task: {}", e);
+        tracing::error!("failed to join Python module task: {e}");
         EX_SOFTWARE
     })??;
 

--- a/src/registry/github.rs
+++ b/src/registry/github.rs
@@ -1,7 +1,7 @@
 // This is free and unencumbered software released into the public domain.
 
 use asimov_env::paths::asimov_root;
-use clientele::{SysexitsError, SysexitsError::*};
+use clientele::SysexitsError::{self, *};
 use color_print::{ceprintln, cprintln};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -66,7 +66,11 @@ pub async fn install_from_github(
     if verbosity > 1 {
         cprintln!("<s,c>»</> Searching for assets on GitHub...");
     }
-    let release = fetch_release(module_name, version).await?;
+    let release = fetch_release(module_name, version).await.inspect_err(|e| {
+        ceprintln!(
+            "<s,r>error:</> failed to fetch release information for module '{module_name}' version '{version}': {e}"
+        )
+    })?;
     let Some(asset) = find_matching_asset(&release.assets, module_name, &platform) else {
         ceprintln!(
             "<s,r>error:</> no matching asset found for platform {}-{}",
@@ -78,15 +82,15 @@ pub async fn install_from_github(
 
     let temp_dir = tempfile::Builder::new()
         .prefix("asimov-module-cli-")
-        .tempdir()?;
+        .tempdir()
+        .inspect_err(|e| ceprintln!("<s,r>error:</> failed to create temporary directory: {e}"))?;
 
     if verbosity > 1 {
         cprintln!("<s,c>»</> Downloading asset from GitHub...");
     }
-    let download = download_asset(asset, temp_dir.path()).await.map_err(|e| {
-        ceprintln!("<s,r>error:</> failed to download asset: {}", e);
-        EX_UNAVAILABLE
-    })?;
+    let download = download_asset(asset, temp_dir.path())
+        .await
+        .inspect_err(|e| ceprintln!("<s,r>error:</> failed to download asset: {e}"))?;
     if verbosity > 0 {
         cprintln!("<s,g>✓</> Downloaded asset `{}`", asset.name);
     }
@@ -101,7 +105,9 @@ pub async fn install_from_github(
             if verbosity > 1 {
                 cprintln!("<s,c>»</> Verifying checksum...");
             }
-            verify_checksum(&download, &checksum).await?;
+            verify_checksum(&download, &checksum)
+                .await
+                .inspect_err(|e| ceprintln!("<s,r>error:</> checksum verification failed: {e}"))?;
             if verbosity > 0 {
                 cprintln!("<s,g>✓</> Verified checksum");
             }
@@ -128,7 +134,14 @@ pub async fn install_module_manifest(
     version: &str,
 ) -> Result<(), SysexitsError> {
     let module_dir = asimov_root().join("modules");
-    tokio::fs::create_dir_all(&module_dir).await?;
+    tokio::fs::create_dir_all(&module_dir)
+        .await
+        .inspect_err(|e| {
+            ceprintln!(
+                "<s,r>error:</> failed to create module directory '{}': {e}",
+                module_dir.display()
+            )
+        })?;
 
     let url = format!(
         "https://raw.githubusercontent.com/asimov-modules/asimov-{}-module/{}/.asimov/module.yaml",
@@ -136,10 +149,13 @@ pub async fn install_module_manifest(
     );
 
     let response = crate::registry::http::http_client()
-        .get(url)
+        .get(&url)
         .send()
         .await
-        .map_err(|_| EX_UNAVAILABLE)?;
+        .map_err(|e| {
+            ceprintln!("<s,r>error:</> failed to fetch module manifest from '{url}': {e}");
+            EX_UNAVAILABLE
+        })?;
 
     if response.status() != 200 {
         ceprintln!(
@@ -149,13 +165,28 @@ pub async fn install_module_manifest(
         return Err(EX_UNAVAILABLE);
     }
 
-    let manifest = response.bytes().await.map_err(|_| EX_UNAVAILABLE)?;
+    let manifest = response.bytes().await.map_err(|e| {
+        ceprintln!("<s,r>error:</> failed to read module manifest response: {e}");
+        EX_UNAVAILABLE
+    })?;
 
     let manifest_filename = module_dir.join(format!("{}.yaml", module_name));
-    let mut manifest_file = tokio::fs::File::create(manifest_filename).await?;
+    let mut manifest_file = tokio::fs::File::create(&manifest_filename)
+        .await
+        .inspect_err(|e| {
+            ceprintln!(
+                "<s,r>error:</> failed to create manifest file '{}': {e}",
+                manifest_filename.display()
+            )
+        })?;
 
     use tokio::io::AsyncWriteExt as _;
-    manifest_file.write_all(&manifest).await?;
+    manifest_file.write_all(&manifest).await.inspect_err(|e| {
+        ceprintln!(
+            "<s,r>error:</> failed to write manifest file '{}': {e}",
+            manifest_filename.display()
+        )
+    })?;
 
     Ok(())
 }
@@ -200,13 +231,20 @@ async fn fetch_release(module_name: &str, version: &str) -> Result<GitHubRelease
     );
 
     let client = super::http::http_client();
-    let response = client.get(&url).send().await?;
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("failed to send request to '{url}': {e}"))?;
 
     if !response.status().is_success() {
         return Err(format!("GitHub API request failed: {}", response.status()).into());
     }
 
-    let release: GitHubRelease = response.json().await?;
+    let release: GitHubRelease = response
+        .json()
+        .await
+        .map_err(|e| format!("failed to parse GitHub release response: {e}"))?;
     Ok(release)
 }
 
@@ -261,7 +299,11 @@ async fn fetch_checksum(asset: &GitHubAsset) -> Result<Option<String>, Box<dyn E
 
     let client = super::http::http_client();
 
-    let response = client.get(&checksum_url).send().await?;
+    let response = client
+        .get(&checksum_url)
+        .send()
+        .await
+        .map_err(|e| format!("failed to fetch checksum from '{checksum_url}': {e}"))?;
 
     if response.status() == 404 {
         return Ok(None);
@@ -279,7 +321,16 @@ async fn download_asset(
     dst_dir: &Path,
 ) -> Result<std::path::PathBuf, Box<dyn Error>> {
     let client = super::http::http_client();
-    let mut response = client.get(&asset.browser_download_url).send().await?;
+    let mut response = client
+        .get(&asset.browser_download_url)
+        .send()
+        .await
+        .map_err(|e| {
+            format!(
+                "failed to start download from '{}': {e}",
+                asset.browser_download_url
+            )
+        })?;
 
     if !response.status().is_success() {
         return Err(format!("Failed to download asset: {}", response.status()).into());
@@ -289,10 +340,18 @@ async fn download_asset(
     let mut dst = tokio::fs::File::create(&asset_path)
         .await
         .map_err(|e| format!("Failed to create file for download: {}", e))?;
-    while let Some(chunk) = response.chunk().await? {
-        dst.write_all(&chunk).await?;
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|e| format!("failed to read download chunk: {e}"))?
+    {
+        dst.write_all(&chunk)
+            .await
+            .map_err(|e| format!("failed to write download chunk: {e}"))?;
     }
-    dst.flush().await?;
+    dst.flush()
+        .await
+        .map_err(|e| format!("failed to flush download file: {e}"))?;
 
     Ok(asset_path)
 }
@@ -302,10 +361,18 @@ async fn verify_checksum(
     expected_checksum: &str,
 ) -> Result<(), Box<dyn Error>> {
     let mut hasher = Sha256::new();
-    let mut file = tokio::fs::File::open(binary_path).await?;
+    let mut file = tokio::fs::File::open(binary_path).await.map_err(|e| {
+        format!(
+            "failed to open file for checksum verification '{}': {e}",
+            binary_path.display()
+        )
+    })?;
     let mut buf = vec![0u8; 10 * 1024];
     loop {
-        let n = file.read(&mut buf).await?;
+        let n = file
+            .read(&mut buf)
+            .await
+            .map_err(|e| format!("failed to read file for checksum verification: {e}"))?;
         if n == 0 {
             break; // End of file
         }
@@ -332,13 +399,28 @@ async fn verify_checksum(
 
 async fn install_binaries(src_asset: &Path, verbosity: u8) -> Result<(), Box<dyn Error>> {
     let install_dir = asimov_root().join("libexec");
-    tokio::fs::create_dir_all(&install_dir).await?;
+    tokio::fs::create_dir_all(&install_dir)
+        .await
+        .inspect_err(|e| {
+            ceprintln!(
+                "<s,r>error:</> failed to create install directory '{}': {e}",
+                install_dir.display()
+            )
+        })?;
 
     let temp_extract_dir = src_asset
         .parent()
         .expect("Incorrect asset directory")
         .join("extracted");
-    tokio::fs::create_dir_all(&temp_extract_dir).await?;
+
+    tokio::fs::create_dir_all(&temp_extract_dir)
+        .await
+        .inspect_err(|e| {
+            ceprintln!(
+                "<s,r>error:</> failed to create extraction directory '{}': {e}",
+                temp_extract_dir.display()
+            )
+        })?;
 
     tokio::task::spawn_blocking({
         let src_asset = src_asset.to_owned();
@@ -360,24 +442,69 @@ async fn install_binaries(src_asset: &Path, verbosity: u8) -> Result<(), Box<dyn
             Ok(())
         }
     })
-    .await??;
+    .await?
+    .inspect_err(|e| ceprintln!("<s,r>error:</> failed to extract archive: {e}"))?;
 
-    let mut read_dir = tokio::fs::read_dir(&temp_extract_dir).await?;
+    let mut read_dir = tokio::fs::read_dir(&temp_extract_dir)
+        .await
+        .inspect_err(|e| {
+            ceprintln!(
+                "<s,r>error:</> failed to read extraction directory '{}': {e}",
+                temp_extract_dir.display()
+            )
+        })?;
 
-    while let Some(entry) = read_dir.next_entry().await? {
-        if !entry.file_type().await?.is_file() {
+    while let Some(entry) = read_dir
+        .next_entry()
+        .await
+        .inspect_err(|e| ceprintln!("<s,r>error:</> failed to read directory entry: {}", e))?
+    {
+        if !entry
+            .file_type()
+            .await
+            .inspect_err(|e| {
+                ceprintln!(
+                    "<s,r>error:</> failed to get file type for '{}': {e}",
+                    entry.path().display(),
+                )
+            })?
+            .is_file()
+        {
             continue;
         }
         let name = entry.file_name();
-        let mut src = tokio::fs::File::open(entry.path()).await?;
+        let mut src = tokio::fs::File::open(entry.path()).await.inspect_err(|e| {
+            ceprintln!(
+                "<s,r>error:</> failed to open source file '{}': {e}",
+                entry.path().display()
+            )
+        })?;
         let dst_path = install_dir.join(&name);
-        let mut dst = tokio::fs::File::create(&dst_path).await?;
-        tokio::io::copy(&mut src, &mut dst).await?;
+        let mut dst = tokio::fs::File::create(&dst_path).await.inspect_err(|e| {
+            ceprintln!(
+                "<s,r>error:</> failed to create destination file '{}': {e}",
+                dst_path.display()
+            )
+        })?;
+        tokio::io::copy(&mut src, &mut dst).await.inspect_err(|e| {
+            ceprintln!(
+                "<s,r>error:</> failed to copy file from '{}' to '{}': {e}",
+                entry.path().display(),
+                dst_path.display(),
+            )
+        })?;
 
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            tokio::fs::set_permissions(dst_path, Permissions::from_mode(0o755)).await?;
+            tokio::fs::set_permissions(&dst_path, Permissions::from_mode(0o755))
+                .await
+                .inspect_err(|e| {
+                    ceprintln!(
+                        "<s,r>error:</> failed to set permissions for '{}': {e}",
+                        dst_path.display()
+                    )
+                })?;
         }
 
         if verbosity > 0 {


### PR DESCRIPTION
I consider this to be a temporary stop-gap for the functions which return `Result<T, SysexitsError>` and thus provide no context beyond the exit code. Long term, we probably want to define proper error types (or even just `s/SysexitsError/miette::Error/` with mappings to `SysexitsError`) for the code on the lib-side as would be a follow-up PR.
Let me know if I misunderstood the desired `tracing` use, we'll drop the second commit if so.