### PR TITLE
Silence uninstall error for module not in registry

### DIFF
--- a/src/commands/disable.rs
+++ b/src/commands/disable.rs
@@ -1,6 +1,6 @@
 // This is free and unencumbered software released into the public domain.
 
-use crate::{registry, StandardOptions, SysexitsError};
+use crate::{StandardOptions, SysexitsError, registry};
 
 pub fn disable(module_names: Vec<String>, _flags: &StandardOptions) -> Result<(), SysexitsError> {
     for module_name in module_names {

--- a/src/commands/enable.rs
+++ b/src/commands/enable.rs
@@ -1,6 +1,6 @@
 // This is free and unencumbered software released into the public domain.
 
-use crate::{registry, StandardOptions, SysexitsError};
+use crate::{StandardOptions, SysexitsError, registry};
 
 pub fn enable(module_names: Vec<String>, _flags: &StandardOptions) -> Result<(), SysexitsError> {
     for module_name in module_names {

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -94,8 +94,8 @@ pub async fn uninstall(
                 }
             }
             None => {
-                tracing::error!("unknown module: {module_name}");
-                return Err(SysexitsError::EX_UNAVAILABLE);
+                tracing::debug!("skipping registry uninstall for unknown module: {module_name}");
+                continue;
             }
         }
     }

--- a/src/registry/crates.rs
+++ b/src/registry/crates.rs
@@ -1,6 +1,6 @@
 // This is free and unencumbered software released into the public domain.
 
-use super::{http::http_client, ModuleMetadata, ModuleType};
+use super::{ModuleMetadata, ModuleType, http::http_client};
 use reqwest::Error;
 use serde::{Deserialize, Serialize};
 

--- a/src/registry/github.rs
+++ b/src/registry/github.rs
@@ -5,7 +5,7 @@ use clientele::SysexitsError::{self, *};
 use color_print::cprintln;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
-use std::{error::Error, fs::Permissions, path::Path};
+use std::{error::Error, path::Path};
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
 #[derive(Debug)]
@@ -493,6 +493,7 @@ async fn install_binaries(src_asset: &Path, verbosity: u8) -> Result<(), Box<dyn
 
         #[cfg(unix)]
         {
+            use std::fs::Permissions;
             use std::os::unix::fs::PermissionsExt;
             tokio::fs::set_permissions(&dst_path, Permissions::from_mode(0o755))
                 .await

--- a/src/registry/pypi.rs
+++ b/src/registry/pypi.rs
@@ -1,6 +1,6 @@
 // This is free and unencumbered software released into the public domain.
 
-use super::{http::http_client, ModuleMetadata, ModuleType};
+use super::{ModuleMetadata, ModuleType, http::http_client};
 use known_types_pypi::PackageMetadata;
 use reqwest::Error;
 

--- a/src/registry/rubygems.rs
+++ b/src/registry/rubygems.rs
@@ -1,6 +1,6 @@
 // This is free and unencumbered software released into the public domain.
 
-use super::{http::http_client, ModuleMetadata, ModuleType};
+use super::{ModuleMetadata, ModuleType, http::http_client};
 use known_types_rubygems::GemInfo;
 use reqwest::Error;
 


### PR DESCRIPTION
Modules installed through GH releases get an useless nag message when uninstalled.

Compare old:
```console
$ cargo run -q -- install jq
$ cargo run -q -- uninstall jq
2025-06-30T21:21:04.019509Z ERROR asimov_module::commands::uninstall: unknown module: jq
$ # uninstall was successful but there the registry is also checked for the given module
```

to new:
```console
$ cargo run -q -- install jq
$ cargo run -q -- uninstall jq
$ echo $?
0
```

@race-of-sloths