### PR TITLE
Add support to `link` and `browse` commands for modules from GH Releases

### DIFF
--- a/src/commands/browse.rs
+++ b/src/commands/browse.rs
@@ -1,5 +1,9 @@
 // This is free and unencumbered software released into the public domain.
 
+use asimov_env::paths::asimov_root;
+use asimov_module::models::ModuleManifest;
+use color_print::ceprintln;
+
 use crate::{
     StandardOptions,
     SysexitsError::{self, *},
@@ -9,19 +13,40 @@ use crate::{
 #[tokio::main]
 pub async fn browse(
     module_name: impl AsRef<str>,
-    _flags: &StandardOptions,
+    flags: &StandardOptions,
 ) -> Result<(), SysexitsError> {
     let module_name = module_name.as_ref();
 
-    match registry::fetch_module(module_name).await {
-        Some(module) => {
-            open::that(&module.url)
-                .inspect_err(|e| tracing::error!("failed to open URL '{}': {e}", module.url))?;
-            Ok(())
+    let manifest_path = asimov_root()
+        .join("modules")
+        .join(format!("{module_name}.yaml"));
+
+    // try installed modules
+    if let Ok(manifest) = tokio::fs::read(&manifest_path).await.inspect_err(|e| {
+        if flags.verbose > 1 {
+            tracing::warn!("install not found for `{module_name}`, failed to read manifest: {e}")
         }
-        None => {
-            eprintln!("unknown module: {}", module_name);
-            Err(EX_UNAVAILABLE)
+    }) {
+        let manifest: ModuleManifest = serde_yml::from_slice(&manifest).map_err(|e| {
+            tracing::error!("failed parse manifest for module `{module_name}`: {e}");
+            EX_UNAVAILABLE
+        })?;
+
+        let mut links = manifest.links;
+        if let Some(link) = links.first() {
+            open::that(link)
+                .inspect_err(|e| tracing::error!("failed to open URL '{link}': {e}"))?;
+            return Ok(());
         }
     }
+
+    // try modules in registries
+    if let Some(module) = registry::fetch_module(module_name).await {
+        open::that(&module.url)
+            .inspect_err(|e| tracing::error!("failed to open URL '{}': {e}", module.url))?;
+        return Ok(());
+    };
+
+    eprintln!("unknown module: {}", module_name);
+    Err(EX_UNAVAILABLE)
 }

--- a/src/commands/browse.rs
+++ b/src/commands/browse.rs
@@ -33,6 +33,8 @@ pub async fn browse(
         })?;
 
         let mut links = manifest.links;
+        crate::sort_links(&manifest.name, &mut links);
+
         if let Some(link) = links.first() {
             open::that(link)
                 .inspect_err(|e| tracing::error!("failed to open URL '{link}': {e}"))?;

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -32,6 +32,7 @@ pub async fn link(
         })?;
 
         let mut links = manifest.links;
+        crate::sort_links(&manifest.name, &mut links);
 
         for link in links {
             println!("{link}");

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -5,21 +5,47 @@ use crate::{
     SysexitsError::{self, *},
     registry,
 };
+use asimov_env::paths::asimov_root;
+use asimov_module::models::ModuleManifest;
+use color_print::ceprintln;
 
 #[tokio::main]
 pub async fn link(
     module_name: impl AsRef<str>,
-    _flags: &StandardOptions,
+    flags: &StandardOptions,
 ) -> Result<(), SysexitsError> {
     let module_name = module_name.as_ref();
-    match registry::fetch_module(module_name).await {
-        Some(module) => {
-            println!("{}", module.url);
-            Ok(())
+
+    let manifest_path = asimov_root()
+        .join("modules")
+        .join(format!("{module_name}.yaml"));
+
+    // try installed modules
+    if let Ok(manifest) = tokio::fs::read(&manifest_path).await.inspect_err(|e| {
+        if flags.verbose > 1 {
+            tracing::warn!("install not found for `{module_name}`, failed to read manifest: {e}")
         }
-        None => {
-            eprintln!("unknown module: {}", module_name);
-            Err(EX_UNAVAILABLE)
+    }) {
+        let manifest: ModuleManifest = serde_yml::from_slice(&manifest).map_err(|e| {
+            tracing::error!("failed parse manifest for module `{module_name}`: {e}");
+            EX_UNAVAILABLE
+        })?;
+
+        let mut links = manifest.links;
+
+        for link in links {
+            println!("{link}");
         }
+
+        return Ok(());
     }
+
+    // try modules in registries
+    if let Some(module) = registry::fetch_module(module_name).await {
+        println!("{}", module.url);
+        return Ok(());
+    };
+
+    eprintln!("unknown module: {}", module_name);
+    Err(EX_UNAVAILABLE)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,52 @@ pub mod options {}
 pub mod registry;
 
 use clientele::{StandardOptions, SysexitsError};
+
+/// Sorts links from a module's manifest in the order that we'd like to display
+/// them for the command `link` and for choosing the URL to open for the command
+/// `browse`.
+pub(crate) fn sort_links(module_name: &str, links: &mut [impl AsRef<str>]) {
+    use std::cmp::Reverse;
+
+    links.sort_by_cached_key(|link| {
+        let Ok(url) = reqwest::Url::parse(link.as_ref()) else {
+            // it's not even a valid url? put it last
+            return Reverse(0);
+        };
+
+        let Some(host) = url.host_str() else {
+            // it doesn't have a host, put it last
+            return Reverse(0);
+        };
+
+        // give highest priority to github links under our org
+        let our_module = link.as_ref().contains("github.com/asimov-modules/") as i8;
+
+        let host_score =
+            // give priority to github links
+            (host.ends_with("github.com") as i8 * 2)
+            // then any of the package indices
+            + ((host.ends_with("crates.io") ||
+                host.ends_with("pypi.org") ||
+                host.ends_with("rubygems.org") ||
+                host.ends_with("npmjs.com")) as i8);
+
+        let path_score = {
+            let path = url.path();
+            // give highest priority to links which contain the exact module name
+            (path.contains(&format!("asimov-{module_name}-module")) as i8 * 3)
+            // next to links which contain `asimov-`
+            + (((path.contains("asimov-")
+                // and `-module`
+                && path.contains("-module")
+                // but not `/asimov-modules/`
+                && !path.contains("/asimov-modules/")) as i8) * 2)
+            // and finally if the path does contain `/asimov-modules/`
+            + (path.contains("/asimov-modules/") as i8)
+        };
+
+        // add all the scores together, then reverse it because we want the highest scores first (sort is ascending order)
+        // (add 1 to differentiate from the invalid/host-less links that we return early for)
+        Reverse(our_module * 5 + host_score + path_score + 1)
+    });
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,7 @@
 
 #![deny(unsafe_code)]
 
-mod commands;
-mod registry;
+use asimov_module_cli::commands;
 
 use clientele::{
     StandardOptions,


### PR DESCRIPTION
Makes commands such as the following work:

```bash
cargo run -q -- link near // near, jq, apify, brightdata, etc.
cargo run -q -- browse near // near, jq, apify, brightdata, etc.
```

Implementation notes: in `link` we get the links from the module's manifest and print them all after some trivial prioritization (sorting). `browse` does the same and opens the first link after sorting.

@race-of-sloths

