### PR TITLE
Disable Cargo/Ruby/Python registry modules

### DIFF
--- a/src/commands/find.rs
+++ b/src/commands/find.rs
@@ -10,10 +10,10 @@ pub fn find(module_name: impl AsRef<str>, _flags: &StandardOptions) -> Result<()
         Some(command) => {
             println!("{}", command.path.display());
             Ok(())
-        }
+        },
         None => {
             eprintln!("unknown module: {}", module_name);
             Err(SysexitsError::EX_UNAVAILABLE)
-        }
+        },
     }
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -61,7 +61,7 @@ pub async fn install(
                         "<s,g>✓</> Installed the module `{module_name}` from GitHub releases."
                     );
                 }
-            }
+            },
             Err(err) => {
                 tracing::warn!(
                     "Install from GitHub releases failed: {err}, trying install from registry..."
@@ -74,11 +74,11 @@ pub async fn install(
                         } else {
                             continue;
                         }
-                    }
+                    },
                     None => {
                         tracing::error!("unknown module: {module_name}");
                         return Err(EX_UNAVAILABLE);
-                    }
+                    },
                 };
 
                 use registry::ModuleType::*;
@@ -96,7 +96,7 @@ pub async fn install(
                     Ruby => RubyEnv::default().install_module(&module.name, Some(venv_verbosity)),
                     Python => {
                         PythonEnv::default().install_module(&module.name, Some(venv_verbosity))
-                    }
+                    },
                 };
 
                 match result {
@@ -107,11 +107,11 @@ pub async fn install(
                             module.r#type.to_string()
                         );
                         return Err(EX_UNAVAILABLE);
-                    }
+                    },
                     Err(err) => {
                         tracing::error!("failed to install module `{}`: {err}", module.name);
                         return Err(EX_OSERR);
-                    }
+                    },
                     Ok(status) if !status.success() => {
                         tracing::error!(
                             "failed to install module `{}`: exit code {}",
@@ -119,7 +119,7 @@ pub async fn install(
                             status.code().unwrap_or_default()
                         );
                         return Err(EX_SOFTWARE);
-                    }
+                    },
                     Ok(_) => {
                         if flags.verbose > 0 {
                             cprintln!(
@@ -128,9 +128,9 @@ pub async fn install(
                                 module.r#type.origin(),
                             );
                         }
-                    }
+                    },
                 };
-            }
+            },
         }
     }
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -30,7 +30,7 @@ pub async fn list(flags: &StandardOptions) -> Result<(), SysexitsError> {
                     } else {
                         cprintln!("<s,g>✓</> {}", name);
                     }
-                }
+                },
                 Err(e) => continue,
             }
         }

--- a/src/commands/resolve.rs
+++ b/src/commands/resolve.rs
@@ -59,17 +59,6 @@ pub async fn resolve(url: impl AsRef<str>, _flags: &StandardOptions) -> Result<(
     })?;
 
     for module in modules {
-        // let Some(module) = crate::registry::fetch_module(&module.name).await else {
-        //     continue;
-        // };
-
-        // if module.is_installed()? {
-        //     cprint!("<g,s>✓</> ");
-        // } else {
-        //     cprint!("<r,s>✗</> ");
-        // }
-        // cprintln!("{}", module.name);
-
         cprintln!("{}", module.name);
     }
 

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -24,7 +24,7 @@ pub async fn uninstall(
                 if flags.verbose > 1 {
                     cprintln!("<s,g>✓</> Removed manifest for module `{}`.", module_name);
                 }
-            }
+            },
             Err(err) if err.kind() == ErrorKind::NotFound => (),
             Err(err) => {
                 tracing::error!(
@@ -33,7 +33,7 @@ pub async fn uninstall(
                     err
                 );
                 return Err(SysexitsError::from(err));
-            }
+            },
         };
         Ok(())
     };
@@ -68,12 +68,12 @@ pub async fn uninstall(
                     if flags.verbose > 1 {
                         cprintln!("<s,g>✓</> Removed binary `{}`.", path.display());
                     }
-                }
+                },
                 Err(err) if err.kind() == ErrorKind::NotFound => (),
                 Err(err) => {
                     tracing::error!("failed to remove binary `{}`: {err}", path.display());
                     return Err(SysexitsError::from(err));
-                }
+                },
             }
         }
 
@@ -92,11 +92,11 @@ pub async fn uninstall(
                 if module.is_installed()? {
                     modules_to_uninstall.push(module.clone());
                 }
-            }
+            },
             None => {
                 tracing::debug!("skipping registry uninstall for unknown module: {module_name}");
                 continue;
-            }
+            },
         }
     }
 
@@ -123,11 +123,11 @@ pub async fn uninstall(
                     module.r#type.to_string()
                 );
                 return Err(SysexitsError::EX_UNAVAILABLE);
-            }
+            },
             Err(error) => {
                 tracing::error!("failed to uninstall module `{}`: {}", module.name, error);
                 return Err(SysexitsError::EX_OSERR);
-            }
+            },
             Ok(status) if !status.success() => {
                 tracing::error!(
                     "failed to uninstall module `{}`: exit code {}",
@@ -135,12 +135,12 @@ pub async fn uninstall(
                     status.code().unwrap_or_default()
                 );
                 return Err(SysexitsError::EX_SOFTWARE);
-            }
+            },
             Ok(_) => {
                 if flags.verbose > 0 {
                     cprintln!("<s><g>✓</></> Uninstalled the module `{}`.", module.name);
                 }
-            }
+            },
         }
     }
 

--- a/src/registry/github.rs
+++ b/src/registry/github.rs
@@ -97,7 +97,7 @@ pub async fn install_from_github(
             if verbosity > 1 {
                 cprintln!("<s,y>warning:</> No checksum file found, skipping verification");
             }
-        }
+        },
         Ok(Some(checksum)) => {
             if verbosity > 1 {
                 cprintln!("<s,c>»</> Verifying checksum...");
@@ -108,11 +108,11 @@ pub async fn install_from_github(
             if verbosity > 0 {
                 cprintln!("<s,g>✓</> Verified checksum");
             }
-        }
+        },
         Err(err) => {
             tracing::error!("error while fetching checksum file: {err}");
             return Err(EX_UNAVAILABLE);
-        }
+        },
     }
 
     if verbosity > 1 {


### PR DESCRIPTION
All commands use the `::registry::fetch_modules()` function so stubbing it out is enough to disable install/list/uninstall/etc. for the registry modules. Commands still work for managing modules from GH releases.

This does also disable the rust/cargo registry but we weren't using that anyway and it contains no modules currently.

@race-of-sloths