### PR TITLE
Implement `config` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,8 +126,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asimov-env"
-version = "25.0.0-dev.13"
-source = "git+https://github.com/asimov-platform/asimov.rs?branch=samuel%2Fmodule-config#1e7105be769a6587751c182b6003357b81127ae7"
+version = "25.0.0-dev.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f65778ee204913244ae3bc3e954e28c546a6fd73a68ebe541adbc6246ce7c9b"
 dependencies = [
  "cap-directories",
  "cap-std",
@@ -137,8 +138,9 @@ dependencies = [
 
 [[package]]
 name = "asimov-module"
-version = "25.0.0-dev.13"
-source = "git+https://github.com/asimov-platform/asimov.rs?branch=samuel%2Fmodule-config#1e7105be769a6587751c182b6003357b81127ae7"
+version = "25.0.0-dev.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790f0315926906a7b2f30443fdea20d55e80209f8a1ad17f754d965ef657cc84"
 dependencies = [
  "asimov-env",
  "clientele",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,8 +127,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 [[package]]
 name = "asimov-env"
 version = "25.0.0-dev.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0f4e9abe9ba122b6c880f0022bcdd5fb80e1ee8b9770e8c78731707c64d136"
+source = "git+https://github.com/asimov-platform/asimov.rs?branch=samuel%2Fmodule-config#1e7105be769a6587751c182b6003357b81127ae7"
 dependencies = [
  "cap-directories",
  "cap-std",
@@ -139,15 +138,17 @@ dependencies = [
 [[package]]
 name = "asimov-module"
 version = "25.0.0-dev.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ac8b71da155cde753c1c253d123483dc1a89e1e08400c53b0fc51f40c9a067"
+source = "git+https://github.com/asimov-platform/asimov.rs?branch=samuel%2Fmodule-config#1e7105be769a6587751c182b6003357b81127ae7"
 dependencies = [
+ "asimov-env",
  "clientele",
  "dogma",
  "getenv",
  "secrecy",
  "serde",
+ "serde_yml",
  "slab",
+ "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -628,12 +629,13 @@ dependencies = [
 
 [[package]]
 name = "dogma"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4329b663bcb56cab24a624e8eb2032805e999c3724cd570e3ba1aef5a9d7bb8"
+checksum = "2ba51e88eeeb6858fc7528ed1727f135646230f30c49f2e922b4ffe9c952f9a5"
 dependencies = [
  "iri-string",
  "known-schemes",
+ "serde",
 ]
 
 [[package]]
@@ -1296,9 +1298,13 @@ dependencies = [
 
 [[package]]
 name = "known-schemes"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474d01704cbcb2ed17c7cc1106b950775b9979d983c9b129adbe830cb317c2c"
+checksum = "c000b5392f942e57f412e6dc49400601f435d283d9019a3da92432057d2f7499"
+dependencies = [
+ "iri-string",
+ "serde",
+]
 
 [[package]]
 name = "known-types-pypi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,7 @@ lto = "thin"
 [[bin]]
 name = "asimov-module"
 path = "src/main.rs"
+
+[patch.crates-io]
+asimov-module = { git = "https://github.com/asimov-platform/asimov.rs", branch = "samuel/module-config" }
+asimov-env = { git = "https://github.com/asimov-platform/asimov.rs", branch = "samuel/module-config" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ indoc = "2.0"
 temp-dir = "0.1"
 
 [dependencies]
-asimov-env = "25.0.0-dev.13"
-asimov-module = "25.0.0-dev.13"
+asimov-env = "25.0.0-dev.14"
+asimov-module = "25.0.0-dev.14"
 clap = { version = "4.5", default-features = false }
 clientele = { version = "0.3.8", features = ["serde-json", "tokio"] }
 color-print = "=0.3.7"
@@ -71,7 +71,3 @@ lto = "thin"
 [[bin]]
 name = "asimov-module"
 path = "src/main.rs"
-
-[patch.crates-io]
-asimov-module = { git = "https://github.com/asimov-platform/asimov.rs", branch = "samuel/module-config" }
-asimov-env = { git = "https://github.com/asimov-platform/asimov.rs", branch = "samuel/module-config" }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -5,6 +5,9 @@
 mod browse;
 pub use browse::*;
 
+mod config;
+pub use config::*;
+
 mod disable;
 pub use disable::*;
 

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -128,7 +128,7 @@ pub async fn config(
                     println!("{name}: {}", current.trim());
                 }
             }
-        } else if args.len().is_multiple_of(2) {
+        } else if args.len() % 2 == 0 {
             // pair(s) of (key,value), write into config file(s)
 
             let mut stdin = std::io::stdin().lock().lines();

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,0 +1,22 @@
+// This is free and unencumbered software released into the public domain.
+
+use asimov_env::paths::asimov_root;
+use clientele::{
+    StandardOptions,
+    SysexitsError::{self, *},
+};
+use color_print::ceprintln;
+
+#[tokio::main]
+pub async fn config(module_name: String, flags: &StandardOptions) -> Result<(), SysexitsError> {
+    let conf_bin = asimov_root()
+        .join("libexec")
+        .join(format!("asimov-{module_name}-configurator"));
+
+    if !tokio::fs::try_exists(&conf_bin).await.unwrap_or(false) {
+        ceprintln!("<s,r>error:</> module `{module_name}` has no configurator to run");
+        return Err(EX_UNAVAILABLE);
+    }
+
+    Ok(())
+}

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,6 +1,9 @@
 // This is free and unencumbered software released into the public domain.
 
+use std::io::{BufRead, Write};
+
 use asimov_env::paths::asimov_root;
+use asimov_module::models::ModuleManifest;
 use clientele::{
     StandardOptions,
     SysexitsError::{self, *},
@@ -8,14 +11,117 @@ use clientele::{
 use color_print::ceprintln;
 
 #[tokio::main]
-pub async fn config(module_name: String, flags: &StandardOptions) -> Result<(), SysexitsError> {
+pub async fn config(
+    module_name: String,
+    args: &[String],
+    flags: &StandardOptions,
+) -> Result<(), SysexitsError> {
+    let manifest = ModuleManifest::read_manifest(&module_name).inspect_err(|e| {
+        ceprintln!("<s,r>error:</> failed to read manifest for module `{module_name}`: {e}")
+    })?;
+
+    let mod_has_conf_vars = manifest
+        .config
+        .as_ref()
+        .is_some_and(|conf| !conf.variables.is_empty());
+
+    let first_arg_is_key = if args.is_empty() {
+        false
+    } else {
+        manifest
+            .config
+            .as_ref()
+            .is_some_and(|conf| conf.variables.iter().any(|var| var.name == args[0]))
+    };
+
+    if mod_has_conf_vars && (args.is_empty() || first_arg_is_key) {
+        let profile = "default"; // TODO
+
+        let conf_dir = asimov_root()
+            .join("configs")
+            .join(profile)
+            .join(&module_name);
+
+        tokio::fs::create_dir_all(&conf_dir).await.inspect_err(|e| {
+            ceprintln!("<s,r>error:</> failed to create configuration directory for module `{module_name}`: {e}");
+        })?;
+
+        if args.is_empty() {
+            // interactively prompt for each value in the config
+
+            let mut prompt_for_value = {
+                let mut stdout = std::io::stdout().lock();
+                let mut stdin = std::io::stdin().lock().lines();
+                move |name: &str, desc: Option<&str>| {
+                    write!(&mut stdout, "Give an value for `{name}`")?;
+                    if let Some(desc) = desc {
+                        write!(&mut stdout, " (description: `{desc}`)")?;
+                    }
+                    writeln!(&mut stdout)?;
+
+                    loop {
+                        write!(&mut stdout, "> ")?;
+                        stdout.flush()?;
+
+                        if let Some(line) = stdin.next() {
+                            return line;
+                        }
+                    }
+                }
+            };
+
+            for var in manifest.config.unwrap_or_default().variables {
+                let var_file = conf_dir.join(&var.name);
+
+                let md = tokio::fs::metadata(&var_file).await;
+                if md.is_err_and(|err| err.kind() == std::io::ErrorKind::NotFound) {
+                    let value = prompt_for_value(&var.name, var.description.as_deref())?;
+                    tokio::fs::write(&var_file, &value).await?;
+                }
+            }
+        } else if args.len() == 1 {
+            // one arg, fetch the value
+
+            let name = &args[0];
+            if !manifest
+                .config
+                .is_some_and(|conf| conf.variables.iter().any(|var| var.name == *name))
+            {
+                return Ok(());
+            }
+            let var_file = conf_dir.join(name);
+            let value = tokio::fs::read_to_string(&var_file).await?;
+            println!("{value}")
+        } else if args.len().is_multiple_of(2) {
+            // pair(s) of (key,value), write into config file(s)
+
+            let mut chunks = args.chunks_exact(2);
+            while let Some([name, value]) = chunks.next() {
+                let var_file = conf_dir.join(name);
+                tokio::fs::write(&var_file, &value).await?;
+            }
+        }
+    }
+
+    let provides_configurator = manifest
+        .provides
+        .programs
+        .iter()
+        .any(|program| *program == format!("asimov-{module_name}-configurator"));
+
     let conf_bin = asimov_root()
         .join("libexec")
         .join(format!("asimov-{module_name}-configurator"));
 
-    if !tokio::fs::try_exists(&conf_bin).await.unwrap_or(false) {
-        ceprintln!("<s,r>error:</> module `{module_name}` has no configurator to run");
-        return Err(EX_UNAVAILABLE);
+    let configurator_exists = tokio::fs::try_exists(&conf_bin).await.unwrap_or(false);
+
+    if provides_configurator && configurator_exists {
+        std::process::Command::new(&conf_bin)
+            .args(args)
+            .stdin(std::process::Stdio::inherit())
+            .stdout(std::process::Stdio::inherit())
+            .stderr(std::process::Stdio::inherit())
+            .status();
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,9 @@ enum Command {
     Config {
         /// The name of the module to configure
         name: String,
+
+        #[clap(trailing_var_arg = true)]
+        args: Vec<String>,
     },
 
     /// TBD
@@ -134,7 +137,7 @@ pub fn main() -> SysexitsError {
     // Execute the given command:
     let result = match options.command.unwrap() {
         Command::Browse { name } => commands::browse(name, &options.flags),
-        Command::Config { name } => commands::config(name, &options.flags),
+        Command::Config { name, args } => commands::config(name, &args, &options.flags),
         #[cfg(feature = "unstable")]
         Command::Disable { names } => commands::disable(names, &options.flags),
         #[cfg(feature = "unstable")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,8 @@ enum Command {
         name: String,
     },
 
-    /// TBD
+    /// Configure an installed module
+    #[clap(override_usage = CONFIG_USAGE)]
     Config {
         /// The name of the module to configure
         name: String,
@@ -160,3 +161,9 @@ pub fn main() -> SysexitsError {
         Err(err) => err,
     }
 }
+
+const CONFIG_USAGE: &str = r#"
+    config <module>                     # Interactive configuration
+    config <module> <key>               # Show value for key
+    config <module> [<key> <value>]...  # Set key(s) to value(s)
+"#;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,12 @@ enum Command {
     },
 
     /// TBD
+    Config {
+        /// The name of the module to configure
+        name: String,
+    },
+
+    /// TBD
     #[cfg(feature = "unstable")]
     Disable {
         /// The names of the modules to disable
@@ -128,6 +134,7 @@ pub fn main() -> SysexitsError {
     // Execute the given command:
     let result = match options.command.unwrap() {
         Command::Browse { name } => commands::browse(name, &options.flags),
+        Command::Config { name } => commands::config(name, &options.flags),
         #[cfg(feature = "unstable")]
         Command::Disable { names } => commands::disable(names, &options.flags),
         #[cfg(feature = "unstable")]


### PR DESCRIPTION
Implements the subcommand `config` with usage:

```
    config <module>                     # Interactive configuration
    config <module> <key>               # Show value for key
    config <module> [<key> <value>]...  # Set key(s) to value(s)
```

After configuring _known keys_ to `$ASIMOV_ROOT/configs/default/$module/$key` also invokes `asimov-$module-configurator` (if present) with the rest of the args.

@race-of-sloths