### PR TITLE
Implement `upgrade` command

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -46,7 +46,7 @@ pub async fn install(
             })?;
         if flags.verbose > 1 {
             cprintln!(
-                "<s,g>✓</> Fetched module manifest for module `{}`",
+                "<s,g>✓</> Installed module manifest for module `{}`",
                 module_name,
             );
         }

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -42,6 +42,16 @@ pub async fn upgrade(
             cprintln!("<s,c>»</> Upgrading module '{module_name}'...");
         }
 
+        install_module_manifest(&module_name, &latest)
+            .await
+            .inspect_err(|e| {
+                tracing::error!("failed to install module manifest for `{module_name}`")
+            })?;
+
+        if flags.verbose > 1 {
+            cprintln!("<s,g>✓</> Installed new module manifest for module `{module_name}`")
+        }
+
         install_from_github(&module_name, &latest, flags.verbose)
             .await
             .inspect_err(|_| {

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -39,7 +39,7 @@ pub async fn upgrade(
         }
 
         if flags.verbose > 1 {
-            cprintln!("<s,c>»</>Upgrading module '{module_name}'...");
+            cprintln!("<s,c>»</> Upgrading module '{module_name}'...");
         }
 
         install_from_github(&module_name, &latest, flags.verbose)

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -1,7 +1,56 @@
 // This is free and unencumbered software released into the public domain.
 
-use crate::{StandardOptions, SysexitsError};
+use color_print::{ceprintln, cprintln};
 
-pub fn upgrade(_module_names: Vec<String>, _flags: &StandardOptions) -> Result<(), SysexitsError> {
-    Ok(()) // TODO
+use crate::{
+    StandardOptions, SysexitsError,
+    registry::github::{
+        fetch_latest_release, install_from_github, installed_modules, installed_version,
+    },
+};
+
+#[tokio::main]
+pub async fn upgrade(
+    module_names: Vec<String>,
+    flags: &StandardOptions,
+) -> Result<(), SysexitsError> {
+    let module_names = if !module_names.is_empty() {
+        module_names
+    } else {
+        installed_modules()
+            .await
+            .inspect_err(|e| ceprintln!("<s,r>error:</> failed to read installed modules: {e}"))?
+    };
+    for module_name in module_names {
+        let Some(installed) = installed_version(&module_name).await? else {
+            ceprintln!("<s,y>warn:</> Module '{module_name}' is not installed, skipping...");
+            continue;
+        };
+
+        let latest = fetch_latest_release(&module_name).await.inspect_err(|_| {
+            ceprintln!("<s,r>error:</> failed to check latest release version of '{module_name}'")
+        })?;
+
+        if installed == latest {
+            if flags.verbose > 0 {
+                cprintln!("<s,g>✓</> Module '{module_name}' already has latest version installed");
+            }
+            continue;
+        }
+
+        if flags.verbose > 1 {
+            cprintln!("<s,c>»</>Upgrading module '{module_name}'...");
+        }
+
+        install_from_github(&module_name, &latest, flags.verbose)
+            .await
+            .inspect_err(|_| {
+                ceprintln!("<s,r>error:</> failed to upgrade module '{module_name}'")
+            })?;
+
+        if flags.verbose > 0 {
+            cprintln!("<s,g>✓</> Upgraded module '{module_name}' to version '{latest}'.");
+        }
+    }
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,8 +100,7 @@ enum Command {
         names: Vec<String>,
     },
 
-    /// TBD
-    #[cfg(feature = "unstable")]
+    /// Upgrades currently installed modules. By default all.
     #[clap(alias = "update")]
     Upgrade {
         /// The names of the modules to upgrade
@@ -152,7 +151,6 @@ pub fn main() -> SysexitsError {
         Command::List {} => commands::list(&options.flags),
         Command::Resolve { url } => commands::resolve(url, &options.flags),
         Command::Uninstall { names } => commands::uninstall(names, &options.flags),
-        #[cfg(feature = "unstable")]
         Command::Upgrade { names } => commands::upgrade(names, &options.flags),
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,9 @@ enum Command {
         names: Vec<String>,
     },
 
-    /// Upgrades currently installed modules. By default all.
+    /// Upgrades currently installed modules.
+    ///
+    /// By default upgrades all installed modules.
     #[clap(alias = "update")]
     Upgrade {
         /// The names of the modules to upgrade

--- a/src/registry/github.rs
+++ b/src/registry/github.rs
@@ -30,7 +30,7 @@ struct GitHubAsset {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct InstalledModuleManifest {
-    pub version: String,
+    pub version: Option<String>,
 
     #[serde(flatten)]
     pub manifest: ModuleManifest,
@@ -93,7 +93,7 @@ pub async fn installed_version(module_name: &str) -> Result<Option<String>, Syse
         EX_UNAVAILABLE
     })?;
 
-    Ok(Some(manifest.version))
+    Ok(manifest.version)
 }
 
 pub async fn fetch_latest_release(module_name: &str) -> Result<String, SysexitsError> {
@@ -242,7 +242,7 @@ pub async fn install_module_manifest(
     })?;
 
     let manifest = InstalledModuleManifest {
-        version: version.to_string(),
+        version: Some(version.to_string()),
         manifest,
     };
 


### PR DESCRIPTION
1. Enables `upgrade` command. Updates either all modules or given names (from args).
2. Adds `version` field to installed manifests
3. Handles upgrade from current manifests graciously

Example flow upgrading a previously-versionless module:
```console
$ cargo run -q -- upgrade -vv apify
» Upgrading module 'apify'...
✓ Installed new module manifest for module `apify`
» Searching for assets on GitHub...
» Downloading asset from GitHub...
✓ Downloaded asset `asimov-apify-module-macos-arm.tar.gz`
» Verifying checksum...
✓ Verified checksum
» Installing binaries...
✓ Installed binary `asimov-apify-importer`
✓ Installed binary `asimov-apify-fetcher`
✓ Upgraded module 'apify' to version '0.1.2'.

$ cargo run -q -- upgrade -vv apify
✓ Module 'apify' already has latest version 0.1.2 installed
```

Planning next iterations:
1. Translate upstream YAML manifests to JSON on install
2. Move most of module management internals to `asimov.rs`'s `asimov-module` crate

@race-of-sloths