### PR TITLE
Enable modules by default on `install`

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -4,42 +4,121 @@ use crate::{
     StandardOptions,
     SysexitsError::{self, *},
 };
-use color_print::cprintln;
+use asimov_module::{ConfigurationVariable, InstalledModuleManifest};
+use color_print::{ceprintln, cprintln};
 
 #[tokio::main]
 pub async fn install(
     module_names: Vec<String>,
     flags: &StandardOptions,
 ) -> Result<(), SysexitsError> {
+    let registry = asimov_registry::Registry::default();
     let installer = asimov_installer::Installer::default();
     for module_name in module_names {
-        let latest = installer
-            .fetch_latest_release(&module_name)
+        if !registry
+            .is_module_installed(&module_name)
             .await
-            .map_err(|e| {
-                tracing::error!("unable to find latest release for module `{module_name}`: {e}");
-                EX_UNAVAILABLE
-            })?;
+            .unwrap_or(false)
+        {
+            let latest = installer
+                .fetch_latest_release(&module_name)
+                .await
+                .map_err(|e| {
+                    tracing::error!(
+                        "unable to find latest release for module `{module_name}`: {e}"
+                    );
+                    EX_UNAVAILABLE
+                })?;
 
-        if flags.verbose > 0 {
-            cprintln!("<s,g>✓</> Found latest version <s>{latest}</> for module `{module_name}`.");
+            if flags.verbose > 0 {
+                cprintln!(
+                    "<s,g>✓</> Found latest version <s>{latest}</> for module `<s>{module_name}</>`."
+                );
+            }
+
+            if flags.verbose > 1 {
+                cprintln!("<s,c>»</> Installing module `<s>{module_name}</>`...");
+            }
+
+            installer
+                .install_module(&module_name, &latest)
+                .await
+                .map_err(|e| {
+                    tracing::error!("failed to install for module `{module_name}`: {e}");
+                    EX_UNAVAILABLE
+                })?;
+
+            if flags.verbose > 0 {
+                cprintln!("<s,g>✓</> Installed module `<s>{module_name}</>`.");
+            }
+        } else {
+            if flags.verbose > 0 {
+                cprintln!("<s,g>✓</> Module `<s>{module_name}</>` is already installed.");
+            }
         }
 
-        if flags.verbose > 1 {
-            cprintln!("<s,c>»</> Installing module `{module_name}`...");
+        if registry
+            .is_module_enabled(&module_name)
+            .await
+            .unwrap_or(false)
+        {
+            continue;
         }
 
-        installer
-            .install_module(&module_name, &latest)
-            .await
-            .map_err(|e| {
-                tracing::error!("failed to install module manifest for `{module_name}`: {e}");
+        let manifest = registry.read_manifest(&module_name).await.map_err(|e| {
+            tracing::error!("failed to read module manifest for `{module_name}`: {e}");
+            EX_UNAVAILABLE
+        })?;
+
+        let configured_variables = manifest.manifest.read_variables(None).unwrap_or_default();
+
+        let variables = manifest
+            .manifest
+            .config
+            .map(|conf| conf.variables)
+            .unwrap_or_default();
+
+        let mut missing_variables = Vec::new();
+        for var in variables {
+            if var.default_value.is_some() || configured_variables.contains_key(&var.name) {
+                continue;
+            }
+            missing_variables.push(var.clone());
+        }
+
+        if missing_variables.is_empty() {
+            registry.enable_module(&module_name).await.map_err(|e| {
+                tracing::error!("failed to enable installed module `{module_name}`: {e}");
                 EX_UNAVAILABLE
             })?;
+        } else {
+            ceprintln!(
+                "<s,y>warn:</> Module `<s>{module_name}</>` can't be enabled automatically due to missing configuration."
+            );
+            ceprintln!("<s,dim>hint:</> Module `<s>{module_name}</>` requires configuration:");
 
-        if flags.verbose > 0 {
-            cprintln!("<s,g>✓</> Installed module `{module_name}`.");
+            for var in missing_variables {
+                let desc_suffix = var
+                    .description
+                    .map(|desc| std::format!(" (Description: \"{desc}\")"))
+                    .unwrap_or("".into());
+                ceprintln!(
+                    "<s,dim>hint:</>   Missing variable: <s>{}</s>{}",
+                    var.name,
+                    desc_suffix
+                );
+
+                if let Some(env) = var.environment {
+                    ceprintln!(
+                        "<s,dim>hint:</>   Alternative: set environment variable: <s>{env}</>"
+                    );
+                }
+            }
+
+            ceprintln!("<s,dim>hint:</>   To configure: <s>asimov module config {module_name}</s>");
+            ceprintln!("<s,dim>hint:</>   To enable: <s>asimov module enable {module_name}</s>");
         }
     }
+
     Ok(())
 }


### PR DESCRIPTION
- When installing modules enable them by default if not missing configuration.

  Example when missing configuration:
  <img width="752" height="199" alt="Screenshot 2025-08-07 at 13 16 06" src="https://github.com/user-attachments/assets/573d35c8-5a5b-4e50-ab93-9f7368535061" />

  to get the same prints you may do the following,
  add to `~/.asimov/modules/installed/http.json`:
  ```json
  "config": {
    "variables": [
      {
        "name": "foobar1",
        "description": "Controls the combobulator",
        "environment": "FOOBAR"
      },
      {
        "name": "foobar2"
      }
    ]
  },
  ```
  then:
  ```console
  $ cargo run -q -- disable http
  $ cargo run -q -- install http
  ```

- Fixes `install` on already installed modules, no longer gives an error. Reinstall also reattempts the enable step meaning user can rerun the install command to try again or to show the instructions

Before merging:
1. How do you feel about the screenshot warn/hint wording and formatting?
2. The warn/hint messages are printed to STDERR regardless of verbosity level, is this acceptable? There's a pretty steep tradeoff between doing the "normal" `tracing::warn` & `tracing::info` which would only show on `-vv` (I believe? Didn't verify with the tracing subscriber that we use) and being useful and informative when something "unexpected" (to the user) happens, leaving the module disabled. The default without `-vv` means silently doing install and not enabling, leaving user confused about the state of the module.

@race-of-sloths